### PR TITLE
ATD-31 Implemented Join Us Header

### DIFF
--- a/atd/src/app/components/join-us-header/join-us-header.component.html
+++ b/atd/src/app/components/join-us-header/join-us-header.component.html
@@ -1,0 +1,8 @@
+<div class="container">
+    <div class="title">Join Us</div>
+    <div class="body">
+        We are a team that visions to be the largest student centric - club on campus. 
+        We want to build a home where students can grow, flourish and discover anything they 
+        put their minds to.
+    </div>
+</div>

--- a/atd/src/app/components/join-us-header/join-us-header.component.scss
+++ b/atd/src/app/components/join-us-header/join-us-header.component.scss
@@ -1,0 +1,26 @@
+@use "src/styles/fonts" as *;
+@use "src/styles/colors" as *;
+
+.title {
+    font-family: $font-primary;
+    font-weight: $font-weight-bold;
+    font-size: $font-size-header-lg;
+    color: $brand-color-white;
+    margin-bottom: 2rem;
+}
+
+.body {
+    font-family: $font-secondary;
+    font-weight: $font-weight-regular;
+    font-size: $font-size-sm;
+    color: $brand-color-white;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    justify-content: center;
+    width: 700px;
+    aspect-ratio: 3;
+}

--- a/atd/src/app/components/join-us-header/join-us-header.component.spec.ts
+++ b/atd/src/app/components/join-us-header/join-us-header.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { JoinUsHeaderComponent } from './join-us-header.component';
+
+describe('JoinUsHeaderComponent', () => {
+  let component: JoinUsHeaderComponent;
+  let fixture: ComponentFixture<JoinUsHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [JoinUsHeaderComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(JoinUsHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/atd/src/app/components/join-us-header/join-us-header.component.ts
+++ b/atd/src/app/components/join-us-header/join-us-header.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-join-us-header',
+  imports: [],
+  templateUrl: './join-us-header.component.html',
+  styleUrl: './join-us-header.component.scss'
+})
+export class JoinUsHeaderComponent {
+
+}

--- a/atd/src/app/components/join-us-header/join-us-header.stories.ts
+++ b/atd/src/app/components/join-us-header/join-us-header.stories.ts
@@ -1,0 +1,21 @@
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { JoinUsHeaderComponent } from './join-us-header.component';
+
+const meta: Meta<JoinUsHeaderComponent> = {
+  title: 'Components/JoinUsHeader',
+  component: JoinUsHeaderComponent,
+  tags: ['autodocs'],
+  decorators: [
+    (story) => ({
+      ...story(),
+      template: `<div style="background-color: black; padding: 20px;">${story().template}</div>`,
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<JoinUsHeaderComponent>;
+
+export const Primary: Story = {
+  args: {},
+};


### PR DESCRIPTION
Implemented join us header. Note that the black background is only part of Storybook, and is not part of the component.
<img width="826" alt="Screenshot 2025-06-03 at 1 05 55 PM" src="https://github.com/user-attachments/assets/d6fe957a-b527-48bf-bd8a-d9c2cb051925" />
