### PR TITLE
ATD-39 Resizing Navbar, Footer, Main Page

### DIFF
--- a/.github/instructions/copilot_atd_instr.instructions.md
+++ b/.github/instructions/copilot_atd_instr.instructions.md
@@ -1,0 +1,83 @@
+---
+applyTo: '**'
+---
+# Project Description
+
+You are assisting developers in programming a frontend application for a UC Davis design club organization called All Things Design, acroynmed ATD.
+The frontend application will be viewed by the general public, with its main visitor segments:
+- **Potential New Members**: College students at UC Davis, or incoming freshmens to UC Davis, who are interested in design and have interest in joining the club.
+- **Potential Clients**: Local businesses in Davis, California, who are interested in hiring the club for design-related projects.
+
+# Technical Stack
+The frontend application is built using:
+- **Angular**, for the frontend framework and overall application structure.
+- **Storybook**, for modular component development and testing.
+- **Figma**, for the finalized website designs.
+
+Keep in mind that we are not using unit tests for this product. Therefore, while we should have default spec files, they are untouched.
+We also do not have a backend, and there are no components which require such functionality.
+
+# Accessing Designs
+Only when explictly told by the user to access the designs of the website, the designs for the frontend application are available in the Figma file at the following link:
+- Landing Page (Main Page in Code): https://www.figma.com/design/e09p4DWuscen1bQ8RWcxcr/ATD-Frontend-Website?node-id=696-1416&t=f6FxBsrhUh7f2lXX-4
+- About Us Page: https://www.figma.com/design/e09p4DWuscen1bQ8RWcxcr/ATD-Frontend-Website?node-id=696-1267&t=LCvMIhFoubQ3ISHm-4
+- Our Works Page: https://www.figma.com/design/e09p4DWuscen1bQ8RWcxcr/ATD-Frontend-Website?node-id=696-1208&t=LCvMIhFoubQ3ISHm-4
+- Join Us Page: https://www.figma.com/design/e09p4DWuscen1bQ8RWcxcr/ATD-Frontend-Website?node-id=696-1129&t=LCvMIhFoubQ3ISHm-4
+
+You have access to a Model Context Protocol (MCP) called `figma-mcp-server`, that allows you to directly access these files. If you do not have access, ask the user to set up this MCP.
+
+# Coding Style
+The coding style taken in this project adheres to the following standards:
+- **Modularity**: Components are modular and as independent as possible, with minimal dependencies on other components. They should be easily reuseable.
+    - Individual files are also split into as many smaller files as possible, with each file having a single responsibility. For example, define a component's relevant model as a separate file.
+- **Simplicity**: Component files, especially the HTML and SCSS files, should be kept as simple as possible, with logic that is easy to follow. 
+    - In parts where they have any possibility of being unclear or complex, write clear comments to explain what the relevent code does.
+
+# Codebase Structure
+The structure of the codebase follows the standard Angular structure:
+- All components are placed in the `src/app/components` directory.
+- All components' storybook files are placed in the same directory as the component, with the same name as the component but with a `.stories.ts` suffix
+- If a component has a relevant model, it is placed in the same directory as the component, with the same name as the component but with a `.model.ts` suffix.
+- All styles are placed in the `src/app/styles` directory, and are imported into the `src/styles.scss` file.
+- All pages are placed in the `src/app/pages` directory.
+- All assets are placed in the `src/assets` directory, and they are split into subdirectories based on their type (e.g. `images`, `icons`, `headshots`).
+- All services are placed in the `src/app/services` directory.
+
+Each Angular component and page therefore has the following structure:
+```
+src/app/components/<component-name>/
+├── <component-name>.component.html
+├── <component-name>.component.scss
+├── <component-name>.component.spec.ts (untouched)
+└── <component-name>.stories.ts
+├── <component-name>.component.ts
+├── <component-name>.model.ts (optional)
+```
+
+# Response Formats
+When the user prompts you with any request, take the following steps:
+1. **Clarification**: Always start by clarifying the request. At any point where there is uncertainty, do not hesitate to ask for more information.
+2. **User Perspective**: Then, start with user/stakeholder perspective before discussing technical solutions.
+3. **List Approaches**: Then, if discussing technical solutions, use reasoning to first think about the best approaches. 
+    Then, given them all, showing the pros and cons of each. Finally, decide on which one you would recommend. 
+    Do not modify any code at all in this phase. Ask for confirmation on which approach to use before continuing.
+    Keep in mind that the user may ask for clarification or give more context on the problem in response to this step, so always respond then with refined approaches. 
+    Never write code before the user confirms to advance.
+4. **Writing Code**: Once the user confirms the approach, write the code with the **Coding Style** and **Codebase Structre** in primary mind.
+5. **Acceptance Criteria**: Include validation strategies and success criteria in all solutions.
+6. **Refining**: If the user asks for refinements, they may give a list of items that needs to be fixed. 
+    Always work on each one individually, then ask for confirmation to continue onto the next item. 
+    Before editing any code, always provide what you think is the cause of the problem, and how you plan to fix it. 
+    Always ask for confirmation before continuing to implement your solution.
+    Never start the next item without user confirmation.
+7. **Conclusion**: Once the user's original prompt is resolved, provide a short and concise summary of the solution. Style the summary as a commit message to Github.
+
+Remember to remain concise in your responses. Be straight to the point, and use direct and concise language whenever possible. 
+
+# Your Audience
+Keep in mind of the following of the user that is prompting you:
+- **Technical Level**: The user is a junior developer who has general understanding of the Angular framework, but have basic understanding of HTML, SCSS, and Typescript.
+    Therefore, make sure to explain any intermediate concepts for Angular, HTML, and SCSS that is used in your response.
+
+
+

--- a/atd/src/app/components/button/button.component.scss
+++ b/atd/src/app/components/button/button.component.scss
@@ -30,10 +30,4 @@
     transform: translateY(0); // Reset transform on click
     opacity: 1; // Full opacity on click
   }
-
-  &:focus {
-    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3); // Focus ring for accessibility
-  }
-
-
 }

--- a/atd/src/app/components/button/button.component.scss
+++ b/atd/src/app/components/button/button.component.scss
@@ -8,7 +8,7 @@
 
 
 .button-wrapper button {
-  padding: 15px 40px; // Increased padding for more space between text and border
+  padding: 10px 30px; // Increased padding for more space between text and border
   border: 2px solid transparent; // Thicker default transparent border
   cursor: pointer;
 

--- a/atd/src/app/components/contact-box/contact-box.component.scss
+++ b/atd/src/app/components/contact-box/contact-box.component.scss
@@ -2,37 +2,74 @@
 
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
 
 .contact-box {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 20px;
+  padding: clamp(20px, 4vw, 40px);
   border-radius: 20px;
-  width: 100%; // Changed from fixed 1303px to responsive 100%
-  aspect-ratio: 2.25; // Maintain aspect ratio;
+  width: 100%; // Responsive width
+  aspect-ratio: 2.25; // Desktop aspect ratio
   margin: auto;
   background-color: $brand-color-black;
-
   box-sizing: border-box; // Ensure padding is included in width
 
+  @include respond-to('tablet') {
+    aspect-ratio: 1.75; // Shorter and wider for tablet
+    border-radius: 16px;
+  }
+
+  @include respond-to('mobile') {
+    aspect-ratio: 1.4; // More square for mobile
+    border-radius: 12px;
+    padding: 15px;
+  }
 }
 
 .title-box {
   display: flex;
   color: $brand-color-white;
   font-family: $font-primary;
-  font-size: $font-size-base;
+  font-size: $font-size-base; // Desktop
   font-weight: $font-weight-bold;
   gap: 20px;
   padding: 20px 0 0 0;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base-sm;
+    gap: 15px;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+    gap: 10px;
+    padding: 15px 0 0 0;
+  }
 }
+
 .left-dot {
   padding: 2px 0 0 0;
+
+  @include respond-to('mobile') {
+    img {
+      width: 12px;
+      height: 12px;
+    }
+  }
 }
+
 .right-dot {
   padding: 2px 0 0 0;
+
+  @include respond-to('mobile') {
+    img {
+      width: 12px;
+      height: 12px;
+    }
+  }
 }
 
 .description-box {
@@ -41,8 +78,20 @@
   color: $brand-color-white;
   padding: 15px 0 30px 0;
   font-family: $font-secondary;
-  font-size: $font-size-xs;
+  font-size: $font-size-xs; // Desktop
   font-weight: $font-weight-regular;
+  text-align: center;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-xs;
+    padding: 12px 0 25px 0;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-xxs;
+    padding: 10px 0 20px 0;
+    max-width: 280px;
+  }
 }
 
 .input-wrapper {
@@ -50,22 +99,35 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  //gap: 5px;
 }
 
 input[type="email"] {
-  width: 35%;
+  width: 35%; // Desktop width
   height: 45px;
   padding: 0 0 0 12px;
   margin: 0;
   border: 1px solid $brand-color-white;
   font-family: $font-secondary;
-  font-size: $font-size-xs;
+  font-size: $font-size-xs; // Desktop
   font-weight: $font-weight-regular;
+  border-radius: 4px 0 0 4px;
+
+  @include respond-to('tablet') {
+    width: 50%;
+    height: 42px;
+    font-size: $font-size-xxs;
+  }
+
+  @include respond-to('mobile') {
+    width: 70%;
+    height: 38px;
+    font-size: $font-size-xxs;
+    padding: 0 0 0 8px;
+  }
 }
 
 button {
-  width: 39px;
+  width: 39px; // Desktop
   height: 45px;
   padding: 0;
   display: flex;
@@ -75,6 +137,21 @@ button {
   background-color: $brand-color-black;
   border-radius: 0 4px 4px 0;
   cursor: pointer;
+
+  @include respond-to('tablet') {
+    width: 36px;
+    height: 42px;
+  }
+
+  @include respond-to('mobile') {
+    width: 32px;
+    height: 38px;
+
+    img {
+      width: 20px;
+      height: 20px;
+    }
+  }
 }
 
 
@@ -94,4 +171,19 @@ button {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.logo-box {
+  img {
+    width: 120px; // Desktop
+    aspect-ratio: 1;
+
+    @include respond-to('tablet') {
+      width: 90px;
+    }
+
+    @include respond-to('mobile') {
+      width: 60px;
+    }
+  }
 }

--- a/atd/src/app/components/definition-box/definition-box.component.scss
+++ b/atd/src/app/components/definition-box/definition-box.component.scss
@@ -18,7 +18,7 @@
   box-shadow: 0 69px 19px 0 rgba(0, 0, 0, 0), 0 44px 18px 0 rgba(0, 0, 0, 0.01),
     0 25px 15px 0 rgba(0, 0, 0, 0.05), 0 11px 11px 0 rgba(0, 0, 0, 0.09),
     0 3px 6px 0 rgba(0, 0, 0, 0.1);
-  width: 1000px;
+  width: 800px;
   aspect-ratio: 4;
   box-sizing: border-box;
 }
@@ -31,17 +31,17 @@
 .logo-box {
   .logo {
     height: auto;
-    width: 48px;
+    width: 40px;
   }
 }
 
 .title-box {
   display: flex;
+  align-items: center;
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  font-size: $font-size-base-sm;
+  font-size: $font-size-base;
   gap: 7px;
-  font-size: 40px;
   .title {
     color: $brand-color-black;
   }
@@ -57,6 +57,7 @@
 }
 
 .bottom-row {
+  padding-top: 10px;
   font-size: 28px;
   .definition-box {
     display: flex;

--- a/atd/src/app/components/definition-box/definition-box.component.scss
+++ b/atd/src/app/components/definition-box/definition-box.component.scss
@@ -2,36 +2,70 @@
 
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
 
 .definition-box-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-
   justify-content: center;
   background-color: $brand-color-gray-4;
-
-
-  padding: 5% 5%;
+  padding: 5% 5%; // Desktop padding
   border: 2px solid transparent;
   border-radius: 20px;
   box-shadow: 0 69px 19px 0 rgba(0, 0, 0, 0), 0 44px 18px 0 rgba(0, 0, 0, 0.01),
     0 25px 15px 0 rgba(0, 0, 0, 0.05), 0 11px 11px 0 rgba(0, 0, 0, 0.09),
     0 3px 6px 0 rgba(0, 0, 0, 0.1);
-  width: 800px;
-  aspect-ratio: 4;
+  width: 800px; // Desktop width
+  aspect-ratio: 4; // Desktop aspect ratio
   box-sizing: border-box;
+
+  @include respond-to('tablet') {
+    width: 90%;
+    max-width: 600px;
+    aspect-ratio: 3.5;
+    padding: 6% 6%;
+    border-radius: 16px;
+  }
+
+  @include respond-to('mobile') {
+    width: 95%;
+    max-width: 400px;
+    aspect-ratio: 2.5;
+    padding: 6% 5%;
+    border-radius: 12px;
+  }
 }
 
 .top-row {
   display: flex;
   justify-content: center;
-  gap: 23px;
+  gap: 23px; // Desktop gap
+
+  @include respond-to('tablet') {
+    gap: 18px;
+  }
+
+  @include respond-to('mobile') {
+    gap: 15px;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
 }
+
 .logo-box {
   .logo {
     height: auto;
-    width: 40px;
+    width: 40px; // Desktop size
+
+    @include respond-to('tablet') {
+      width: 35px;
+    }
+
+    @include respond-to('mobile') {
+      width: 30px;
+    }
   }
 }
 
@@ -40,8 +74,20 @@
   align-items: center;
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  font-size: $font-size-base;
+  font-size: $font-size-base; // Desktop
   gap: 7px;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base-sm;
+    gap: 6px;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+    gap: 5px;
+    justify-content: center;
+  }
+
   .title {
     color: $brand-color-black;
   }
@@ -57,8 +103,17 @@
 }
 
 .bottom-row {
-  padding-top: 10px;
+  padding-top: 10px; // Desktop spacing
   font-size: 28px;
+
+  @include respond-to('tablet') {
+    padding-top: 8px;
+  }
+
+  @include respond-to('mobile') {
+    padding-top: 6px;
+  }
+
   .definition-box {
     display: flex;
     flex-direction: column;
@@ -66,14 +121,32 @@
     justify-content: center;
     text-align: center;
   }
+
   .definition {
     text-align: center;
     font-family: $font-secondary;
     font-weight: $font-weight-regular;
-    font-size: $font-size-sm;
+    font-size: $font-size-sm; // Desktop
+
+    @include respond-to('tablet') {
+      font-size: $font-size-xs;
+    }
+
+    @include respond-to('mobile') {
+      font-size: $font-size-xxs;
+    }
   }
+
   .definition2 {
     text-align: center;
     margin-top: -20px;
+
+    @include respond-to('tablet') {
+      margin-top: -15px;
+    }
+
+    @include respond-to('mobile') {
+      margin-top: -10px;
+    }
   }
 }

--- a/atd/src/app/components/event-box/event-box.component.scss
+++ b/atd/src/app/components/event-box/event-box.component.scss
@@ -2,24 +2,38 @@
 
 @use "colors" as *;
 @use "fonts" as *;
-
-
+@use "breakpoints" as *;
 
 .event-box-container {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   background-color: $brand-color-white;
-  padding: 5% 5%;
+  padding: 5% 5%; // Desktop padding
   border: 2px solid transparent;
   border-radius: 10px;
   box-shadow: 0 64px 18px 0 rgba(0, 0, 0, 0), 0 41px 16px 0 rgba(0, 0, 0, 0.01),
     0 23px 14px 0 rgba(0, 0, 0, 0.05), 0 10px 10px 0 rgba(0, 0, 0, 0.09),
     0 3px 6px 0 rgba(0, 0, 0, 0.1);
 
-  width: 400px;
-  aspect-ratio: 10 / 7;
+  width: 400px; // Desktop width
+  aspect-ratio: 10 / 7; // Desktop aspect ratio
   box-sizing: border-box;
+
+  @include respond-to('tablet') {
+    width: 300px;
+    aspect-ratio: 4 / 3;
+    padding: 4% 4%;
+    border-radius: 8px;
+  }
+
+  @include respond-to('mobile') {
+    width: 280px;
+    max-width: 90vw;
+    aspect-ratio: 3.5 / 3;
+    padding: 5% 5%;
+    border-radius: 8px;
+  }
 }
 
 .event-box-container.next-event {
@@ -36,18 +50,44 @@
   color: $brand-color-primary;
   font-family: $font-primary;
   font-weight: $font-weight-bold;
+  
   .day {
-    font-size: $font-size-lg;
+    font-size: $font-size-lg; // Desktop
+
+    @include respond-to('tablet') {
+      font-size: $font-size-base;
+    }
+
+    @include respond-to('mobile') {
+      font-size: $font-size-base-sm;
+    }
   }
+  
   .month {
-    font-size: $font-size-base;
+    font-size: $font-size-base; // Desktop
+
+    @include respond-to('tablet') {
+      font-size: $font-size-base-sm;
+    }
+
+    @include respond-to('mobile') {
+      font-size: $font-size-sm;
+    }
   }
 }
 
 .logo-box {
   .logo {
     height: auto;
-    width: 53.08px;
+    width: 53.08px; // Desktop
+
+    @include respond-to('tablet') {
+      width: 45px;
+    }
+
+    @include respond-to('mobile') {
+      width: 40px;
+    }
   }
 }
 
@@ -55,11 +95,22 @@
   .detail-box {
     .title-time,
     .location {
-      height: 30px;
+      height: 30px; // Desktop
       font-family: $font-secondary;
-      font-size: $font-size-sm;
+      font-size: $font-size-sm; // Desktop
       font-weight: $font-weight-regular;
       margin: 0;
+
+      @include respond-to('tablet') {
+        height: 25px;
+        font-size: $font-size-xs;
+      }
+
+      @include respond-to('mobile') {
+        height: auto;
+        line-height: 1.3;
+        font-size: $font-size-xxs;
+      }
     }
   }
 }

--- a/atd/src/app/components/event-box/event-box.component.scss
+++ b/atd/src/app/components/event-box/event-box.component.scss
@@ -17,7 +17,7 @@
     0 23px 14px 0 rgba(0, 0, 0, 0.05), 0 10px 10px 0 rgba(0, 0, 0, 0.09),
     0 3px 6px 0 rgba(0, 0, 0, 0.1);
 
-  width: 550px;
+  width: 400px;
   aspect-ratio: 10 / 7;
   box-sizing: border-box;
 }

--- a/atd/src/app/components/event-calender-box/event-calender-box.component.scss
+++ b/atd/src/app/components/event-calender-box/event-calender-box.component.scss
@@ -2,6 +2,8 @@
 
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
+
 .container {
   background-color: $brand-color-gray-3;
   width: 100%;
@@ -10,11 +12,22 @@
 
 .header {
   font-family: $font-primary;
-  font-size: $font-size-base;
+  font-size: $font-size-base; // Desktop
   font-weight: $font-weight-bold;
   padding-bottom: 1rem;
   width: 100%; // Take full width of the inner container
   text-align: left; // Ensure left alignment
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base-sm;
+    text-align: center;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+    text-align: center;
+    padding-bottom: 0.75rem;
+  }
 }
 
 .event-calendar-wrapper {
@@ -22,19 +35,51 @@
   flex-direction: column;
   justify-content: center;
   align-items: center; // This centers event-calendar-inner
-  padding: 3rem 1rem; // Reduced horizontal padding from 5rem to 1rem for more space
+  padding: 3rem 1rem; // Desktop padding
+
+  @include respond-to('tablet') {
+    padding: 2rem 1rem;
+  }
+
+  @include respond-to('mobile') {
+    padding: 1.5rem 0.5rem;
+  }
 }
 
 .event-calendar-inner {
-  padding: 1rem;
+  padding: 1rem; // Desktop padding
   display: flex;
   flex-direction: column; // Changed to column to stack header and events
   width: fit-content; // Set to 90% to allow centering by the wrapper
+
+  @include respond-to('tablet') {
+    padding: 0.75rem;
+    width: 100%;
+    max-width: 800px;
+  }
+
+  @include respond-to('mobile') {
+    padding: 0.5rem;
+    width: 100%;
+  }
 }
 
 .events-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1rem; // Desktop gap
   width: fit-content;
+
+  @include respond-to('tablet') {
+    justify-content: center;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  @include respond-to('mobile') {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+  }
 }

--- a/atd/src/app/components/faq-item/faq-item.component.html
+++ b/atd/src/app/components/faq-item/faq-item.component.html
@@ -1,4 +1,4 @@
-<div class="faq-item">
+<div class="faq-item" [class.expanded]="isExpanded">
   <div class="faq-header" (click)="toggle()">
     <span class="faq-title">{{ faqItem.question }}</span>
     <mat-icon

--- a/atd/src/app/components/faq-item/faq-item.component.scss
+++ b/atd/src/app/components/faq-item/faq-item.component.scss
@@ -3,7 +3,32 @@
 @use "colors" as *;
 @use "fonts" as *;
 
-$transition-time: 1.0s;
+$transition-time: 0.5s;
+
+// Keyframe animations for bounce effects
+@keyframes faq-expand-bounce {
+  0% { max-height: 0; }
+  70% { max-height: 650px; } // Overshoot beyond normal 600px
+  100% { max-height: 600px; } // Settle to normal
+}
+
+@keyframes faq-collapse-bounce {
+  0% { max-height: 600px; }
+  70% { max-height: -50px; } // Undershoot below normal
+  100% { max-height: 0; }
+}
+
+@keyframes icon-expand-bounce {
+  0% { transform: rotate(0deg); }
+  70% { transform: rotate(200deg); } // Overshoot beyond 180deg
+  100% { transform: rotate(180deg); } // Settle to normal
+}
+
+@keyframes icon-collapse-bounce {
+  0% { transform: rotate(180deg); }
+  70% { transform: rotate(-20deg); } // Undershoot below 180deg
+  100% { transform: rotate(0deg); }
+}
 
 .faq-item {
   display: flex;
@@ -46,14 +71,9 @@ $transition-time: 1.0s;
     48px
   ); // Responsive icon size with max limit
   transform: rotate(0deg);
-  transition: transform $transition-time ease;
   color: $brand-color-primary;
   flex-shrink: 0;
 
-}
-
-.toggle-icon.expanded {
-  transform: rotate(180deg);
 }
 
 .faq-body {
@@ -62,18 +82,28 @@ $transition-time: 1.0s;
   line-height: 1.4; // Slightly increased for better readability
   max-height: 0;
   overflow: hidden;
-  transition: max-height $transition-time ease;
   font-family: $font-secondary;
-
   p {
     white-space: pre-line; // Respect newline characters
     margin: 0;
     word-wrap: break-word; // Ensure long words wrap properly
+    transform: translateY(0); // Keep text stationary during bounce
+    transition: none; // No bounce effect on text
   }
 }
 
 .faq-body.expanded {
+  animation: faq-expand-bounce $transition-time ease-out forwards;
+}
 
-  max-height: 600px;
+.faq-body:not(.expanded) {
+  animation: faq-collapse-bounce $transition-time ease-out forwards;
+}
 
+.toggle-icon.expanded {
+  animation: icon-expand-bounce $transition-time ease-out forwards;
+}
+
+.toggle-icon:not(.expanded) {
+  animation: icon-collapse-bounce $transition-time ease-out forwards;
 }

--- a/atd/src/app/components/faq-item/faq-item.component.scss
+++ b/atd/src/app/components/faq-item/faq-item.component.scss
@@ -27,11 +27,11 @@ $transition-time: 0.5s;
 
 @keyframes faq-body-expand {
   0% { max-height: 0 }
-  100% { max-height: 200px; }
+  100% { max-height: 500px; } // Increased significantly to accommodate mobile text wrapping
 }
 
 @keyframes faq-body-collapse {
-  0% { max-height: 200px; }
+  0% { max-height: 500px; }
   100% { max-height: 0 }
 }
 

--- a/atd/src/app/components/faq-item/faq-item.component.scss
+++ b/atd/src/app/components/faq-item/faq-item.component.scss
@@ -79,6 +79,11 @@ $transition-time: 0.5s;
   max-width: 100%; // Ensure item doesn't exceed container width
   padding-bottom: 0;
   margin-bottom: 0;
+  transition: transform 0.3s ease;
+  
+  &:hover {
+    transform: translateY(-2px); // Subtle hover effect
+  }
 }
 
 .faq-header {

--- a/atd/src/app/components/faq-item/faq-item.component.scss
+++ b/atd/src/app/components/faq-item/faq-item.component.scss
@@ -3,6 +3,8 @@
 @use "colors" as *;
 @use "fonts" as *;
 
+$transition-time: 1.0s;
+
 .faq-item {
   display: flex;
   flex-direction: column;
@@ -44,7 +46,7 @@
     48px
   ); // Responsive icon size with max limit
   transform: rotate(0deg);
-  transition: transform 0.5s ease;
+  transition: transform $transition-time ease;
   color: $brand-color-primary;
   flex-shrink: 0;
 
@@ -60,7 +62,7 @@
   line-height: 1.4; // Slightly increased for better readability
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease;
+  transition: max-height $transition-time ease;
   font-family: $font-secondary;
 
   p {

--- a/atd/src/app/components/faq-item/faq-item.component.scss
+++ b/atd/src/app/components/faq-item/faq-item.component.scss
@@ -1,21 +1,38 @@
-
-
 @use "colors" as *;
 @use "fonts" as *;
 
 $transition-time: 0.5s;
 
 // Keyframe animations for bounce effects
-@keyframes faq-expand-bounce {
-  0% { max-height: 0; }
-  70% { max-height: 650px; } // Overshoot beyond normal 600px
-  100% { max-height: 600px; } // Settle to normal
+@keyframes faq-item-expand-bounce {
+  0% { 
+    padding-bottom: 0;
+  }
+  70% { 
+    padding-bottom: 40px; // Overshoot - pushes border further down
+  }
+  100% { 
+    padding-bottom: 20px; // Settle to normal expanded state
+  }
 }
 
-@keyframes faq-collapse-bounce {
-  0% { max-height: 600px; }
-  70% { max-height: -50px; } // Undershoot below normal
-  100% { max-height: 0; }
+@keyframes faq-item-collapse-bounce {
+  0% { 
+    padding-bottom: 20px;
+  }
+  100% { 
+    padding-bottom: 0;
+  }
+}
+
+@keyframes faq-body-expand {
+  0% { max-height: 0 }
+  100% { max-height: 200px; }
+}
+
+@keyframes faq-body-collapse {
+  0% { max-height: 200px; }
+  100% { max-height: 0 }
 }
 
 @keyframes icon-expand-bounce {
@@ -30,14 +47,38 @@ $transition-time: 0.5s;
   100% { transform: rotate(0deg); }
 }
 
+.faq-item.expanded {
+  animation: faq-item-expand-bounce $transition-time ease-out forwards;
+}
+
+.faq-item:not(.expanded) {
+  animation: faq-item-collapse-bounce $transition-time ease-out forwards;
+}
+
+.faq-body.expanded {
+  animation: faq-body-expand $transition-time*1.3 ease-out forwards;
+}
+
+.faq-body:not(.expanded) {
+  animation: faq-body-collapse $transition-time*1.3 ease-out forwards;
+}
+
+.toggle-icon.expanded {
+  animation: icon-expand-bounce $transition-time ease-out forwards;
+}
+
+.toggle-icon:not(.expanded) {
+  animation: icon-collapse-bounce $transition-time ease-out forwards;
+}
+
 .faq-item {
   display: flex;
   flex-direction: column;
   cursor: pointer;
   border-bottom: 1px solid $brand-color-primary;
-
   max-width: 100%; // Ensure item doesn't exceed container width
-
+  padding-bottom: 0;
+  margin-bottom: 0;
 }
 
 .faq-header {
@@ -90,20 +131,4 @@ $transition-time: 0.5s;
     transform: translateY(0); // Keep text stationary during bounce
     transition: none; // No bounce effect on text
   }
-}
-
-.faq-body.expanded {
-  animation: faq-expand-bounce $transition-time ease-out forwards;
-}
-
-.faq-body:not(.expanded) {
-  animation: faq-collapse-bounce $transition-time ease-out forwards;
-}
-
-.toggle-icon.expanded {
-  animation: icon-expand-bounce $transition-time ease-out forwards;
-}
-
-.toggle-icon:not(.expanded) {
-  animation: icon-collapse-bounce $transition-time ease-out forwards;
 }

--- a/atd/src/app/components/faq-section/faq-section.component.scss
+++ b/atd/src/app/components/faq-section/faq-section.component.scss
@@ -8,20 +8,20 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 1000px;
+  min-height: 200px; // Reduced from 1000px to 800px to make content more compact
   width: 100%;
   overflow: hidden; // Prevent background from overflowing
 }
 
 .faq-background-img {
   position: absolute;
-  top: 70%;
+  top: 65%; // Adjusted from 70% to 65% to better center the content within the background
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
   height: 100%;
   min-width: 1512px; // Minimum size based on SVG viewBox
-  min-height: 1199px; // Minimum size based on SVG viewBox
+  min-height: 1100px; // Reduced from 1199px to 1100px to make background more compact
   object-fit: cover;
   z-index: 1;
 }
@@ -31,7 +31,7 @@
   z-index: 2;
   width: 70%;
   max-width: 1200px; // Increased maximum width for wider FAQ items
-  padding: 60px 40px;
+  padding: 30px 40px; // Reduced padding from 60px to 30px to make items closer to top
   box-sizing: border-box;
 }
 
@@ -47,7 +47,7 @@
   ); // Responsive font size with max limit
 
   font-weight: $font-weight-bold;
-  margin-bottom: 40px;
+  margin-bottom: 25px; // Reduced from 40px to 25px to bring items closer to title
   text-align: center;
 }
 
@@ -57,7 +57,7 @@
 
 app-faq-item {
   display: block;
-  margin-bottom: 20px;
+  margin-bottom: 12px; // Reduced from 20px to 12px to make items closer together
 
   font-size: clamp(
     $font-size-xs,

--- a/atd/src/app/components/faq-section/faq-section.component.scss
+++ b/atd/src/app/components/faq-section/faq-section.component.scss
@@ -29,7 +29,7 @@
 .faq-content {
   position: relative;
   z-index: 2;
-  width: 100%;
+  width: 70%;
   max-width: 1200px; // Increased maximum width for wider FAQ items
   padding: 60px 40px;
   box-sizing: border-box;

--- a/atd/src/app/components/faq-section/faq-section.component.scss
+++ b/atd/src/app/components/faq-section/faq-section.component.scss
@@ -8,20 +8,20 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 200px; // Reduced from 1000px to 800px to make content more compact
+  min-height: 200px; 
   width: 100%;
   overflow: hidden; // Prevent background from overflowing
 }
 
 .faq-background-img {
   position: absolute;
-  top: 65%; // Adjusted from 70% to 65% to better center the content within the background
+  top: 65%;
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
   height: 100%;
   min-width: 1512px; // Minimum size based on SVG viewBox
-  min-height: 1100px; // Reduced from 1199px to 1100px to make background more compact
+  min-height: 1100px;
   object-fit: cover;
   z-index: 1;
 }
@@ -30,8 +30,8 @@
   position: relative;
   z-index: 2;
   width: 70%;
-  max-width: 1200px; // Increased maximum width for wider FAQ items
-  padding: 30px 40px; // Reduced padding from 60px to 30px to make items closer to top
+  max-width: 1200px; 
+  padding: 30px 40px;
   box-sizing: border-box;
 }
 
@@ -47,7 +47,7 @@
   ); // Responsive font size with max limit
 
   font-weight: $font-weight-bold;
-  margin-bottom: 25px; // Reduced from 40px to 25px to bring items closer to title
+  margin-bottom: 25px;
   text-align: center;
 }
 
@@ -57,7 +57,7 @@
 
 app-faq-item {
   display: block;
-  margin-bottom: 12px; // Reduced from 20px to 12px to make items closer together
+  margin-bottom: 12px; 
 
   font-size: clamp(
     $font-size-xs,

--- a/atd/src/app/components/faq-section/faq-section.component.scss
+++ b/atd/src/app/components/faq-section/faq-section.component.scss
@@ -8,20 +8,20 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 200px; 
+  min-height: 1000px;
   width: 100%;
   overflow: hidden; // Prevent background from overflowing
 }
 
 .faq-background-img {
   position: absolute;
-  top: 65%;
+  top: 70%;
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
   height: 100%;
   min-width: 1512px; // Minimum size based on SVG viewBox
-  min-height: 1100px;
+  min-height: 1199px; // Minimum size based on SVG viewBox
   object-fit: cover;
   z-index: 1;
 }
@@ -31,7 +31,7 @@
   z-index: 2;
   width: 70%;
   max-width: 1200px; 
-  padding: 30px 40px;
+  padding: 60px 40px;
   box-sizing: border-box;
 }
 
@@ -47,7 +47,7 @@
   ); // Responsive font size with max limit
 
   font-weight: $font-weight-bold;
-  margin-bottom: 25px;
+  margin-bottom: 40px;
   text-align: center;
 }
 
@@ -57,7 +57,7 @@
 
 app-faq-item {
   display: block;
-  margin-bottom: 12px; 
+  margin-bottom: 20px;
 
   font-size: clamp(
     $font-size-xs,

--- a/atd/src/app/components/footer/footer.component.scss
+++ b/atd/src/app/components/footer/footer.component.scss
@@ -40,7 +40,6 @@
   }
 }
 .title {
-  // Remove flex: 1 since we're using grid now
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -68,7 +67,6 @@
   }
 }
 .link-list {
-  // Remove flex: 1.5 since we're using grid now
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -93,7 +91,6 @@
   cursor: pointer;
 }
 .contact-section {
-  // Remove flex: 1 since we're using grid now
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -119,25 +116,29 @@
 .contact-button {
   width: 80%; // Desktop default
   height: auto;
-  padding: 1rem 5rem; // Desktop default
+  padding: 1rem 2rem; // Equal horizontal padding
   background-color: $brand-color-gray-1;
   border-radius: 12px;
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  text-align: center;
   font-size: $font-size-base-sm;
   cursor: pointer;
   text-decoration: none;
-  display: inline-block;
+  
+  // Use flexbox for perfect centering
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 
   @include respond-to('tablet') {
     width: 70%;
-    padding: 0.75rem 3rem;
+    padding: 0.75rem 1.5rem; // Equal horizontal padding
   }
 
   @include respond-to('mobile') {
     width: 90%;
-    padding: 0.75rem 1.5rem;
+    padding: 0.75rem 1rem; // Equal horizontal padding
     font-size: $font-size-xs;
   }
 }

--- a/atd/src/app/components/footer/footer.component.scss
+++ b/atd/src/app/components/footer/footer.component.scss
@@ -1,33 +1,89 @@
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
 
 .footer {
   background-color: $brand-color-black;
-  padding: 1rem 6rem;
+  padding: 1rem 6rem; // Desktop default
+
+  @include respond-to('tablet') {
+    padding: 1rem 2rem;
+  }
+
+  @include respond-to('mobile') {
+    padding: 1rem;
+  }
 }
 .footer p {
   margin: 0;
 }
 .container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1.5fr 1fr; // Desktop: 3 columns with middle wider
+  gap: 2rem;
   padding: 2rem 0;
-  min-height: 250px; // Increased from 191px
+  min-height: 250px;
   margin-top: 1rem;
+
+  @include respond-to('tablet') {
+    grid-template-columns: 1fr 1fr; // Tablet: 2 columns
+    gap: 1.5rem;
+    min-height: 200px;
+  }
+
+  @include respond-to('mobile') {
+    grid-template-columns: 1fr; // Mobile: 1 column
+    gap: 1.5rem;
+    text-align: center;
+    min-height: auto;
+    padding: 1.5rem 0;
+  }
 }
 .title {
-  flex: 1;
+  // Remove flex: 1 since we're using grid now
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
+  @include respond-to('tablet') {
+    grid-column: 1; // First column on tablet
+  }
+
+  @include respond-to('mobile') {
+    align-items: center; // Center on mobile
+  }
 }
 .header {
   font-family: $font-primary;
   font-weight: $font-weight-regular;
-  font-size: $font-size-header-sm;
+  font-size: $font-size-header-sm; // Desktop default
   color: $brand-color-white;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+  }
 }
 .link-list {
-  flex: 1.5;
+  // Remove flex: 1.5 since we're using grid now
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 0.75rem;
+
+  @include respond-to('tablet') {
+    grid-column: 2; // Second column on tablet
+    grid-row: 1 / 3; // Span both rows if needed
+    gap: 0.5rem;
+  }
+
+  @include respond-to('mobile') {
+    align-items: center; // Center links on mobile
+    gap: 1rem; // More spacing for touch targets
+  }
 }
 .link {
   font-family: $font-primary;
@@ -37,11 +93,22 @@
   cursor: pointer;
 }
 .contact-section {
-  flex: 1;
+  // Remove flex: 1 since we're using grid now
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: space-between;
+  gap: 1rem;
+
+  @include respond-to('tablet') {
+    grid-column: 1; // First column, second row on tablet
+    grid-row: 2;
+  }
+
+  @include respond-to('mobile') {
+    align-items: center; // Center on mobile
+    text-align: center;
+  }
 }
 .contact-des {
   font-family: $font-primary;
@@ -50,9 +117,9 @@
   color: $brand-color-white;
 }
 .contact-button {
-  width: 80%;
+  width: 80%; // Desktop default
   height: auto;
-  padding: 1rem 5rem;
+  padding: 1rem 5rem; // Desktop default
   background-color: $brand-color-gray-1;
   border-radius: 12px;
   font-family: $font-primary;
@@ -60,6 +127,19 @@
   text-align: center;
   font-size: $font-size-base-sm;
   cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+
+  @include respond-to('tablet') {
+    width: 70%;
+    padding: 0.75rem 3rem;
+  }
+
+  @include respond-to('mobile') {
+    width: 90%;
+    padding: 0.75rem 1.5rem;
+    font-size: $font-size-xs;
+  }
 }
 .footer-bottom {
   border-top: 1px solid $brand-color-white;
@@ -68,6 +148,14 @@
   align-items: center;
   margin: 1rem 0;
   padding-top: 0.5rem;
+  gap: 1rem;
+
+  @include respond-to('mobile') {
+    flex-direction: column;
+    text-align: center;
+    gap: 1rem;
+    padding-top: 1rem;
+  }
 }
 .copyright {
   font-family: $font-secondary;
@@ -78,12 +166,22 @@
 .social-icons {
   display: flex;
   gap: 0.5rem;
-}
 
-.social-icons img {
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
+  @include respond-to('mobile') {
+    gap: 1rem; // Increase gap for easier tapping on mobile
+    justify-content: center;
+  }
+
+  img {
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
 }
 
 .credit {

--- a/atd/src/app/components/footer/footer.component.scss
+++ b/atd/src/app/components/footer/footer.component.scss
@@ -10,7 +10,7 @@
 }
 .container {
   display: flex;
-  padding: 3rem 0;
+  padding: 2rem 0;
   min-height: 250px; // Increased from 191px
   margin-top: 1rem;
 }
@@ -24,14 +24,14 @@
   color: $brand-color-white;
 }
 .link-list {
-  flex: 2;
+  flex: 1.5;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 .link {
   font-family: $font-primary;
-  font-weight: $font-weight-regular;
+  font-weight: $font-weight-light;
   font-size: $font-size-xs;
   color: $brand-color-white;
   cursor: pointer;
@@ -45,12 +45,12 @@
 }
 .contact-des {
   font-family: $font-primary;
-  font-weight: $font-weight-regular;
+  font-weight: $font-weight-light;
   font-size: $font-size-xs;
   color: $brand-color-white;
 }
 .contact-button {
-  width: 70%;
+  width: 80%;
   height: auto;
   padding: 1rem 5rem;
   background-color: $brand-color-gray-1;
@@ -67,10 +67,11 @@
   justify-content: space-between;
   align-items: center;
   margin: 1rem 0;
+  padding-top: 0.5rem;
 }
 .copyright {
   font-family: $font-secondary;
-  font-weight: $font-weight-regular;
+  font-weight: $font-weight-light;
   font-size: $font-size-xxs;
   color: $brand-color-gray-3;
 }

--- a/atd/src/app/components/herosection/herosection.component.scss
+++ b/atd/src/app/components/herosection/herosection.component.scss
@@ -42,7 +42,7 @@
 
     @include respond-to('mobile') {
       // Adjust positioning for mobile if needed
-      top: 50%;
+      top: 55%;
     }
   }
 

--- a/atd/src/app/components/herosection/herosection.component.scss
+++ b/atd/src/app/components/herosection/herosection.component.scss
@@ -6,9 +6,7 @@
   /* Flexible height based on content with minimum height */
   min-height: 400px; /* Minimum height for mobile/small screens */
   width: 100%;
-  height: 75vh;
-
-
+  height: 80vh;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -47,14 +45,14 @@ p {
 
     h1 {
 
-      font-size: 6.5rem;
+      font-size: $font-size-header-lg;
     }
 
     .pre-title {
       margin-bottom: 0rem; /* Remove spacing between pretitle and title */
       margin-top: 4rem; /* Push the pretitle farther down */
-      font-size: 3.5rem;
-      font-weight: normal; /* Remove bold font */
+      font-size: $font-size-header-sm;
+      font-weight: $font-weight-light; /* Remove bold font */
     }
 
     // Style the app-button component within hero section

--- a/atd/src/app/components/herosection/herosection.component.scss
+++ b/atd/src/app/components/herosection/herosection.component.scss
@@ -2,6 +2,8 @@
 
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
+
 .hero-section {
   /* Flexible height based on content with minimum height */
   min-height: 400px; /* Minimum height for mobile/small screens */
@@ -15,6 +17,18 @@
   position: relative;
   overflow: hidden; /* Ensure background image doesn't overflow */
 
+  @include respond-to('tablet') {
+    height: 70vh;
+    min-height: 350px;
+  }
+
+  @include respond-to('mobile') {
+    height: 60vh;
+    min-height: 300px;
+    justify-content: center; // Center content on mobile
+    align-items: center;
+  }
+
   /* Positioning and resizing the SVG file with aspect-fill */
   .hero-image {
     position: absolute;
@@ -25,41 +39,86 @@
     height: 100%;
     object-fit: cover; /* Aspect-fill: image covers entire container */
     object-position: center; /* Center the image within the container */
+
+    @include respond-to('mobile') {
+      // Adjust positioning for mobile if needed
+      top: 50%;
+    }
   }
 
   .hero-content {
     text-align: left; /* Align text to the left */
-    padding: 50px 20px 50px 150px; /* Increase padding to move text (clockwise) */
+    padding: 50px 20px 50px 150px; /* Desktop padding */
     position: relative;
     z-index: 3; /* Ensure content is above background */
     font-family: $font-primary;
 
+    @include respond-to('tablet') {
+      padding: 40px 15px 40px 80px; // Reduced padding for tablet
+    }
 
+    @include respond-to('mobile') {
+      padding: 30px 20px; // Centered padding for mobile
+      text-align: center; // Center text on mobile
+    }
 
-p {
-  margin: 0.5rem 0;
-  font-family: $font-primary;
-  font-size: $font-size-base;
-  font-weight: $font-weight-light;
-}
+    p {
+      margin: 0.5rem 0;
+      font-family: $font-primary;
+      font-size: $font-size-base; // Desktop
+      font-weight: $font-weight-light;
+
+      @include respond-to('tablet') {
+        font-size: $font-size-base-sm;
+      }
+
+      @include respond-to('mobile') {
+        font-size: $font-size-sm;
+        margin: 0.3rem 0;
+      }
+    }
 
     h1 {
+      font-size: $font-size-header-lg; // Desktop
 
-      font-size: $font-size-header-lg;
+      @include respond-to('tablet') {
+        font-size: $font-size-header-base;
+      }
+
+      @include respond-to('mobile') {
+        font-size: $font-size-header-sm;
+      }
     }
 
     .pre-title {
       margin-bottom: 0rem; /* Remove spacing between pretitle and title */
       margin-top: 4rem; /* Push the pretitle farther down */
-      font-size: $font-size-header-sm;
+      font-size: $font-size-header-sm; // Desktop
       font-weight: $font-weight-light; /* Remove bold font */
+
+      @include respond-to('tablet') {
+        font-size: $font-size-header-xs;
+        margin-top: 2rem;
+      }
+
+      @include respond-to('mobile') {
+        font-size: $font-size-base;
+        margin-top: 1rem;
+      }
     }
 
     // Style the app-button component within hero section
     app-button {
-      margin-top: 2rem; // Space between button and title
+      margin-top: 2rem; // Desktop spacing
       display: inline-block;
 
+      @include respond-to('tablet') {
+        margin-top: 1.5rem;
+      }
+
+      @include respond-to('mobile') {
+        margin-top: 1rem;
+      }
     }
   }
 }

--- a/atd/src/app/components/join-us-header/join-us-header.component.scss
+++ b/atd/src/app/components/join-us-header/join-us-header.component.scss
@@ -4,15 +4,15 @@
 .title {
     font-family: $font-primary;
     font-weight: $font-weight-bolder;
-    font-size: $font-size-header-lg;
+    font-size: $font-size-header-base;
     color: $brand-color-white;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
 }
 
 .body {
     font-family: $font-secondary;
     font-weight: $font-weight-regular;
-    font-size: $font-size-base;
+    font-size: $font-size-sm;
     color: $brand-color-white;
 }
 
@@ -21,6 +21,6 @@
     flex-direction: column;
     align-items: left;
     justify-content: center;
-    width: 1000px;
+    width: 600px;
     aspect-ratio: 3;
 }

--- a/atd/src/app/components/navbar/navbar.component.html
+++ b/atd/src/app/components/navbar/navbar.component.html
@@ -8,7 +8,7 @@
         height="40"
       />
     </button>
-    <span class="atd-text">ATD</span>
+    <span class="atd-text" (click)="navigateTo('/home') "style="cursor: pointer;">ATD</span>
   </div>
 
   <div class="route-buttons">

--- a/atd/src/app/components/navbar/navbar.component.html
+++ b/atd/src/app/components/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <div class="navbar">
-  <div class="home">
-    <button class="logo-button" (click)="navigateTo('/home')">
+  <div class="home" (click)="navigateTo('/home')" style="cursor: pointer;">
+    <button class="logo-button">
       <img
         src="images/logo-white.svg"
         alt="Logo"
@@ -8,10 +8,11 @@
         height="40"
       />
     </button>
-    <span class="atd-text" (click)="navigateTo('/home') "style="cursor: pointer;">ATD</span>
+    <span class="atd-text">ATD</span>
   </div>
 
-  <div class="route-buttons">
+  <!-- Desktop Navigation -->
+  <div class="route-buttons desktop-menu">
     <div class="button1">
       <app-button
         label="About Us"
@@ -40,5 +41,51 @@
       borderColor="#FF00D9"
       (click)="toggleJoinUs()"
     ></app-button>
+  </div>
+
+  <!-- Mobile Hamburger Menu Button -->
+  <button 
+    class="hamburger-menu" 
+    [class.active]="isMobileMenuOpen"
+    (click)="toggleMobileMenu()"
+    aria-label="Toggle navigation menu"
+  >
+    <mat-icon>{{isMobileMenuOpen ? 'close' : 'menu'}}</mat-icon>
+  </button>
+</div>
+
+<!-- Mobile Navigation Overlay -->
+<div class="mobile-nav-overlay" [class.open]="isMobileMenuOpen" (click)="toggleMobileMenu()">
+  <div class="mobile-nav-content" (click)="$event.stopPropagation()">
+    <div class="mobile-nav-item">
+      <app-button
+        label="About Us"
+        backgroundColor="#000000"
+        [textColor]="isAboutUsActive ? '#FF00D9' : 'white'"
+        [isActive]="isAboutUsActive"
+        (click)="toggleAboutUs()"
+      ></app-button>
+    </div>
+
+    <div class="mobile-nav-item">
+      <app-button
+        label="Our Works"
+        backgroundColor="#000000"
+        [textColor]="isOurWorksActive ? '#FF00D9' : 'white'"
+        [isActive]="isOurWorksActive"
+        (click)="toggleOurWorks()"
+      ></app-button>
+    </div>
+
+    <div class="mobile-nav-item">
+      <app-button
+        label="Join Us"
+        [backgroundColor]="isJoinUsActive ? '#FF00D9' : '#FFE3FB'"
+        [textColor]="isJoinUsActive ? 'white' : '#FF00D9'"
+        [isActive]="isJoinUsActive"
+        borderColor="#FF00D9"
+        (click)="toggleJoinUs()"
+      ></app-button>
+    </div>
   </div>
 </div>

--- a/atd/src/app/components/navbar/navbar.component.scss
+++ b/atd/src/app/components/navbar/navbar.component.scss
@@ -17,12 +17,10 @@
   z-index: 1000;
 
   @include respond-to('tablet') {
-    height: 64px;
     padding: 0 2rem;
   }
 
   @include respond-to('mobile') {
-    height: 56px;
     padding: 0 1rem;
   }
 }

--- a/atd/src/app/components/navbar/navbar.component.scss
+++ b/atd/src/app/components/navbar/navbar.component.scss
@@ -3,47 +3,27 @@
 @use "fonts" as *;
 @use "breakpoints" as *;
 
-// CSS Variables for responsive design
-:root {
-  --navbar-height: 100px;
-  --navbar-padding: 75px;
-  --logo-size: 61px;
-  --logo-height: 40px;
-}
-
-@include respond-to('tablet') {
-  :root {
-    --navbar-height: 64px;
-    --navbar-padding: 2rem;
-    --logo-size: 50px;
-    --logo-height: 32px;
-  }
-}
-
-@include respond-to('mobile') {
-  :root {
-    --navbar-height: 56px;
-    --navbar-padding: 1rem;
-    --logo-size: 45px;
-    --logo-height: 28px;
-  }
-}
-
 .navbar {
   display: flex;
   flex-direction: row;
   align-items: center;
   width: 100%;
-  height: var(--navbar-height);
+  height: 100px; // Desktop default
   background-color: $brand-color-black;
-  padding: 0 var(--navbar-padding);
+  padding: 0 75px; // Desktop default
 
   position: sticky;
   top: 0;
   z-index: 1000;
 
+  @include respond-to('tablet') {
+    height: 64px;
+    padding: 0 2rem;
+  }
+
   @include respond-to('mobile') {
-    padding: 0 var(--navbar-padding);
+    height: 56px;
+    padding: 0 1rem;
   }
 }
 
@@ -60,8 +40,18 @@
   margin-right: 0.5rem;
   
   img {
-    width: var(--logo-size);
-    height: var(--logo-height);
+    width: 61px; // Desktop default
+    height: 40px; // Desktop default
+
+    @include respond-to('tablet') {
+      width: 50px;
+      height: 32px;
+    }
+
+    @include respond-to('mobile') {
+      width: 45px;
+      height: 28px;
+    }
   }
 }
 
@@ -143,15 +133,25 @@
 // Mobile Navigation Overlay
 .mobile-nav-overlay {
   position: fixed;
-  top: var(--navbar-height);
+  top: 100px; // Desktop navbar height
   left: 0;
   width: 100%;
-  height: calc(100vh - var(--navbar-height));
+  height: calc(100vh - 100px); // Desktop navbar height
   background-color: rgba(0, 0, 0, 0.8);
   z-index: 999;
   opacity: 0;
   visibility: hidden;
   transition: all 0.3s ease;
+
+  @include respond-to('tablet') {
+    top: 64px;
+    height: calc(100vh - 64px);
+  }
+
+  @include respond-to('mobile') {
+    top: 56px;
+    height: calc(100vh - 56px);
+  }
 
   &.open {
     opacity: 1;

--- a/atd/src/app/components/navbar/navbar.component.scss
+++ b/atd/src/app/components/navbar/navbar.component.scss
@@ -9,7 +9,7 @@
   flex-direction: row;
   align-items: center;
   width: 100%;
-  height: 131px;
+  height: 110px;
   background-color: $brand-color-black;
 
   position: sticky; // Added for sticky behavior
@@ -27,7 +27,7 @@
   border: none;
   cursor: pointer;
   margin-left: 75px;
-  margin-right: 0;
+  margin-right: 5px;
 }
 .atd-text {
   margin-left: -8px;

--- a/atd/src/app/components/navbar/navbar.component.scss
+++ b/atd/src/app/components/navbar/navbar.component.scss
@@ -1,52 +1,197 @@
 
-
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
 
+// CSS Variables for responsive design
+:root {
+  --navbar-height: 100px;
+  --navbar-padding: 75px;
+  --logo-size: 61px;
+  --logo-height: 40px;
+}
+
+@include respond-to('tablet') {
+  :root {
+    --navbar-height: 64px;
+    --navbar-padding: 2rem;
+    --logo-size: 50px;
+    --logo-height: 32px;
+  }
+}
+
+@include respond-to('mobile') {
+  :root {
+    --navbar-height: 56px;
+    --navbar-padding: 1rem;
+    --logo-size: 45px;
+    --logo-height: 28px;
+  }
+}
 
 .navbar {
   display: flex;
   flex-direction: row;
   align-items: center;
   width: 100%;
-  height: 100px;
+  height: var(--navbar-height);
   background-color: $brand-color-black;
+  padding: 0 var(--navbar-padding);
 
-  position: sticky; // Added for sticky behavior
-  top: 0; // Stick to the top
-  z-index: 1000; // Ensure it's above other content
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 
+  @include respond-to('mobile') {
+    padding: 0 var(--navbar-padding);
+  }
 }
+
 .home {
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .logo-button {
   background-color: transparent;
   border: none;
   cursor: pointer;
-  margin-left: 75px;
-  margin-right: 5px;
+  margin-right: 0.5rem;
+  
+  img {
+    width: var(--logo-size);
+    height: var(--logo-height);
+  }
 }
+
 .atd-text {
-  margin-left: -8px;
+  margin-left: -0.5rem;
   color: $brand-color-white;
   font-size: $font-size-header-xs;
   font-weight: $font-weight-regular;
   font-family: $font-primary;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+  }
 }
-.route-buttons {
+
+// Desktop Navigation
+.desktop-menu {
   display: flex;
   flex-direction: row;
-  gap: 15px; /* Uniform gap between all buttons */
+  gap: 1rem;
   align-items: center;
   margin-left: auto;
-  padding-right: 75px; /* Distance from the right edge */
+
+  @include respond-to('tablet') {
+    display: none; // Hide desktop menu on tablet and mobile
+  }
 }
+
+.route-buttons {
+  @include respond-to('tablet') {
+    gap: 0.75rem;
+  }
+}
+
 .button1 {
-  margin-right: 5px;
+  margin-right: 0.3rem;
+
+  @include respond-to('desktop') {
+    margin-right: 0.5rem;
+  }
 }
+
 .button2 {
-  margin-right: 20px;
+  margin-right: 1.25rem;
+
+  @include respond-to('desktop') {
+    margin-right: 1.5rem;
+  }
+}
+
+// Hamburger Menu Button
+.hamburger-menu {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  margin-left: auto;
+
+  @include respond-to('tablet') {
+    display: flex;
+  }
+
+  mat-icon {
+    color: $brand-color-white;
+    font-size: 1.5rem;
+    transition: all 0.3s ease;
+  }
+}
+
+// Mobile Navigation Overlay
+.mobile-nav-overlay {
+  position: fixed;
+  top: var(--navbar-height);
+  left: 0;
+  width: 100%;
+  height: calc(100vh - var(--navbar-height));
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 999;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease;
+
+  &.open {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  @include respond-to('desktop') {
+    display: none; // Never show on desktop
+  }
+}
+
+.mobile-nav-content {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 280px;
+  height: 100%;
+  background-color: $brand-color-black;
+  padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+
+  .mobile-nav-overlay.open & {
+    transform: translateX(0);
+  }
+
+  @include respond-to('mobile') {
+    width: 250px;
+    padding: 1.5rem 1rem;
+    gap: 1.25rem;
+  }
+}
+
+.mobile-nav-item {
+  width: 100%;
+
+  app-button {
+    width: 100%;
+  }
 }

--- a/atd/src/app/components/navbar/navbar.component.scss
+++ b/atd/src/app/components/navbar/navbar.component.scss
@@ -9,7 +9,7 @@
   flex-direction: row;
   align-items: center;
   width: 100%;
-  height: 110px;
+  height: 100px;
   background-color: $brand-color-black;
 
   position: sticky; // Added for sticky behavior

--- a/atd/src/app/components/navbar/navbar.component.ts
+++ b/atd/src/app/components/navbar/navbar.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ButtonComponent } from '../button/button.component';
 import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
-import { filter } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { MatIconModule } from '@angular/material/icon';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'app-navbar',
@@ -13,12 +14,15 @@ import { MatIconModule } from '@angular/material/icon';
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
-export class NavbarComponent implements OnInit {
+export class NavbarComponent implements OnInit, OnDestroy {
   isAboutUsActive: boolean = false;
   isOurWorksActive: boolean = false;
   isJoinUsActive: boolean = false;
   isMobile: boolean = false;
   isMobileMenuOpen: boolean = false;
+
+  // Subject that will emit when the component is destroyed
+  private destroy$ = new Subject<void>();
 
   constructor(
     private router: Router,
@@ -28,7 +32,10 @@ export class NavbarComponent implements OnInit {
   ngOnInit() {
     // Listen to router events to update active states
     this.router.events
-      .pipe(filter(event => event instanceof NavigationEnd))
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
       .subscribe((event: NavigationEnd) => {
         this.updateActiveStates(event.url);
       });
@@ -38,12 +45,19 @@ export class NavbarComponent implements OnInit {
 
     // Monitor mobile breakpoint for hamburger menu
     this.breakpointObserver.observe(['(max-width: 768px)'])
+      .pipe(takeUntil(this.destroy$))
       .subscribe(result => {
         this.isMobile = result.matches;
         if (!this.isMobile) {
           this.isMobileMenuOpen = false; // Close menu when switching to desktop
         }
       });
+  }
+
+  // Cleanup method to prevent memory leaks
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private updateActiveStates(url: string) {

--- a/atd/src/app/components/navbar/navbar.component.ts
+++ b/atd/src/app/components/navbar/navbar.component.ts
@@ -38,6 +38,7 @@ export class NavbarComponent implements OnInit {
 
     // Monitor mobile breakpoint for hamburger menu
     this.breakpointObserver.observe(['(max-width: 768px)'])
+      .pipe(takeUntil(this.destroy$))
       .subscribe(result => {
         this.isMobile = result.matches;
         if (!this.isMobile) {

--- a/atd/src/app/components/navbar/navbar.component.ts
+++ b/atd/src/app/components/navbar/navbar.component.ts
@@ -38,7 +38,6 @@ export class NavbarComponent implements OnInit {
 
     // Monitor mobile breakpoint for hamburger menu
     this.breakpointObserver.observe(['(max-width: 768px)'])
-      .pipe(takeUntil(this.destroy$))
       .subscribe(result => {
         this.isMobile = result.matches;
         if (!this.isMobile) {

--- a/atd/src/app/components/navbar/navbar.component.ts
+++ b/atd/src/app/components/navbar/navbar.component.ts
@@ -3,11 +3,13 @@ import { ButtonComponent } from '../button/button.component';
 import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [ButtonComponent, CommonModule],
+  imports: [ButtonComponent, CommonModule, MatIconModule],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
@@ -15,8 +17,13 @@ export class NavbarComponent implements OnInit {
   isAboutUsActive: boolean = false;
   isOurWorksActive: boolean = false;
   isJoinUsActive: boolean = false;
+  isMobile: boolean = false;
+  isMobileMenuOpen: boolean = false;
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private breakpointObserver: BreakpointObserver
+  ) {}
 
   ngOnInit() {
     // Listen to router events to update active states
@@ -28,6 +35,15 @@ export class NavbarComponent implements OnInit {
 
     // Set initial active state
     this.updateActiveStates(this.router.url);
+
+    // Monitor mobile breakpoint for hamburger menu
+    this.breakpointObserver.observe(['(max-width: 768px)'])
+      .subscribe(result => {
+        this.isMobile = result.matches;
+        if (!this.isMobile) {
+          this.isMobileMenuOpen = false; // Close menu when switching to desktop
+        }
+      });
   }
 
   private updateActiveStates(url: string) {
@@ -38,6 +54,14 @@ export class NavbarComponent implements OnInit {
 
   navigateTo(route: string): void {
     this.router.navigate([route]);
+    // Close mobile menu after navigation
+    if (this.isMobile) {
+      this.isMobileMenuOpen = false;
+    }
+  }
+
+  toggleMobileMenu(): void {
+    this.isMobileMenuOpen = !this.isMobileMenuOpen;
   }
 
   toggleAboutUs() {

--- a/atd/src/app/components/offer-card/offer-card.component.scss
+++ b/atd/src/app/components/offer-card/offer-card.component.scss
@@ -1,23 +1,55 @@
 
 
 @use "fonts" as *;
-
+@use "breakpoints" as *;
 
 .container {
   display: flex;
   flex-direction: column;
   width: fit-content;
-  height: 150px;
+  height: 150px; // Desktop height
+
+  @include respond-to('tablet') {
+    height: 120px;
+  }
+
+  @include respond-to('mobile') {
+    width: 100%;
+    height: auto;
+    margin-bottom: 1.5rem;
+  }
 }
+
 .title {
   font-family: $font-primary;
-  font-size: $font-size-base;
+  font-size: clamp($font-size-base-sm, 3vw, $font-size-base); // Responsive font size
   font-weight: $font-weight-bold;
   margin-bottom: 0.5rem;
+
+  @include respond-to('tablet') {
+    font-size: clamp($font-size-sm, 2.5vw, $font-size-base-sm);
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+    margin-bottom: 0.75rem;
+  }
 }
+
 .description {
   font-family: $font-secondary;
   font-weight: $font-weight-regular;
-  font-size: $font-size-xs;
-  width: 22rem;
+  font-size: clamp($font-size-xxs, 1.5vw, $font-size-xs); // Responsive font size
+  width: clamp(16rem, 22vw, 22rem); // Responsive width
+
+  @include respond-to('tablet') {
+    width: clamp(14rem, 20vw, 18rem);
+    font-size: clamp($font-size-xxs, 1.3vw, $font-size-xs);
+  }
+
+  @include respond-to('mobile') {
+    width: 100%;
+    font-size: $font-size-xxs;
+    line-height: 1.4;
+  }
 }

--- a/atd/src/app/components/team-values-carousel/team-values-carousel.component.scss
+++ b/atd/src/app/components/team-values-carousel/team-values-carousel.component.scss
@@ -10,17 +10,20 @@
   overflow: hidden;
   width: 100%; // Make it take full width of parent
   aspect-ratio: 2.2; // Desktop aspect ratio
+  min-height: 200px; // Minimum height to ensure content visibility
 
   @include respond-to('tablet') {
     border-radius: 16px;
-    aspect-ratio: 2.3;
+    aspect-ratio: 2.0; // Adjusted for better image display on tablet
     box-shadow: 0px 6px 24px rgba(0, 0, 0, 0.4);
+    min-height: 180px;
   }
 
   @include respond-to('mobile') {
     border-radius: 12px;
-    aspect-ratio: 2.5;
+    aspect-ratio: 1.8; // Adjusted for better image display on mobile
     box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+    min-height: 150px;
   }
 }
 
@@ -29,6 +32,15 @@
   width: 100%; // Make background image responsive
   height: 100%; // Fill the container
   object-fit: cover; // Maintain aspect ratio while covering the container
+  object-position: center; // Ensure image is centered
+  
+  @include respond-to('tablet') {
+    object-position: center; // Center the image on tablet
+  }
+  
+  @include respond-to('mobile') {
+    object-position: center; // Center the image on mobile
+  }
 }
 
 .values-container {
@@ -40,6 +52,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding: 0 10px; // Add some horizontal padding
+
+  @include respond-to('tablet') {
+    align-items: center;
+    padding: 0 15px; // More padding on tablet
+  }
 
   @include respond-to('mobile') {
     flex-direction: column;
@@ -53,16 +71,16 @@
 .text-content {
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  font-size: $font-size-header-base; // Desktop
+  font-size: clamp($font-size-xl, 4vw, $font-size-header-base); // Responsive font sizing
   padding-left: 80px; // Desktop padding
 
   @include respond-to('tablet') {
-    font-size: $font-size-xl;
+    font-size: clamp($font-size-base, 3.5vw, $font-size-xl);
     padding-left: 50px;
   }
 
   @include respond-to('mobile') {
-    font-size: $font-size-base-sm;
+    font-size: clamp($font-size-sm, 3vw, $font-size-base-sm);
     padding-left: 0;
     padding: 0 15px;
   }
@@ -75,7 +93,7 @@
 .line-two {
   color: $brand-color-primary;
   overflow: hidden;
-  height: 1em;
+  height: 1.2em; // Increased height for better visibility
 
   .rotating-words {
     display: inline-block;
@@ -118,15 +136,18 @@
   scale: 100%; // Desktop scale
   filter: drop-shadow(-2px -2px 8px rgba(0, 0, 0, 0.6));
   -webkit-filter: drop-shadow(-2px -2px 8px rgba(0, 0, 0, 0.6));
+  max-width: 30%; // Prevent logo from being too large
 
   @include respond-to('tablet') {
     padding-right: 80px;
-    scale: 90%;
+    scale: 85%;
+    max-width: 28%; // Slightly smaller on tablet
   }
 
   @include respond-to('mobile') {
     padding-right: 0;
-    scale: 50%;
+    scale: 60%; // Increased from 50% for better visibility
+    max-width: 35%; // Different proportion on mobile
     filter: drop-shadow(-1px -1px 4px rgba(0, 0, 0, 0.6));
     -webkit-filter: drop-shadow(-1px -1px 4px rgba(0, 0, 0, 0.6));
   }

--- a/atd/src/app/components/team-values-carousel/team-values-carousel.component.scss
+++ b/atd/src/app/components/team-values-carousel/team-values-carousel.component.scss
@@ -1,5 +1,6 @@
 @use "colors" as *;
 @use "fonts" as *;
+@use "breakpoints" as *;
 
 .values-wrapper {
   position: relative;
@@ -8,7 +9,19 @@
   box-shadow: 0px 8px 32px rgba(0, 0, 0, 0.5);
   overflow: hidden;
   width: 100%; // Make it take full width of parent
-  aspect-ratio: 2.2; // Maintain aspect ratio based on the background image
+  aspect-ratio: 2.2; // Desktop aspect ratio
+
+  @include respond-to('tablet') {
+    border-radius: 16px;
+    aspect-ratio: 2.3;
+    box-shadow: 0px 6px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  @include respond-to('mobile') {
+    border-radius: 12px;
+    aspect-ratio: 2.5;
+    box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+  }
 }
 
 .background-image {
@@ -27,13 +40,32 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  @include respond-to('mobile') {
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    gap: 0.5rem;
+    padding: 15px;
+  }
 }
 
 .text-content {
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  font-size: $font-size-header-base;
-  padding-left: 80px;
+  font-size: $font-size-header-base; // Desktop
+  padding-left: 80px; // Desktop padding
+
+  @include respond-to('tablet') {
+    font-size: $font-size-xl;
+    padding-left: 50px;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-base-sm;
+    padding-left: 0;
+    padding: 0 15px;
+  }
 }
 
 .line-one {
@@ -82,8 +114,20 @@
 }
 
 .logo {
-  padding-right: 120px;
-  scale: 100%;
+  padding-right: 120px; // Desktop padding
+  scale: 100%; // Desktop scale
   filter: drop-shadow(-2px -2px 8px rgba(0, 0, 0, 0.6));
   -webkit-filter: drop-shadow(-2px -2px 8px rgba(0, 0, 0, 0.6));
+
+  @include respond-to('tablet') {
+    padding-right: 80px;
+    scale: 90%;
+  }
+
+  @include respond-to('mobile') {
+    padding-right: 0;
+    scale: 50%;
+    filter: drop-shadow(-1px -1px 4px rgba(0, 0, 0, 0.6));
+    -webkit-filter: drop-shadow(-1px -1px 4px rgba(0, 0, 0, 0.6));
+  }
 }

--- a/atd/src/app/components/toggle-button/toggle-button.component.scss
+++ b/atd/src/app/components/toggle-button/toggle-button.component.scss
@@ -2,7 +2,7 @@
 
 @use "colors" as *;
 @use "fonts" as *;
-
+@use "breakpoints" as *;
 
 .toggle-switch {
   position: relative;
@@ -11,8 +11,19 @@
   border-radius: 10px;
   overflow: hidden;
   padding: 0px;
-  height: 65px;
+  height: 65px; // Desktop height
   aspect-ratio: 8/1;
+
+  @include respond-to('tablet') {
+    height: 55px;
+    aspect-ratio: 7/1;
+  }
+
+  @include respond-to('mobile') {
+    height: 45px;
+    aspect-ratio: 6/1;
+    border-radius: 8px;
+  }
 }
 
 .toggle-switch button {
@@ -23,10 +34,18 @@
   z-index: 1;
   font-family: $font-primary;
   font-weight: $font-weight-bold;
-  font-size: $font-size-base;
+  font-size: $font-size-base; // Desktop
   color: $brand-color-black;
   cursor: pointer;
   transition: color 0.3s;
+
+  @include respond-to('tablet') {
+    font-size: $font-size-base-sm;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+  }
 }
 
 .toggle-switch button.selected {
@@ -42,6 +61,10 @@
   background-color: $brand-color-primary;
   transition: left 0.3s;
   border-radius: 10px;
+
+  @include respond-to('mobile') {
+    border-radius: 8px;
+  }
 }
 
 .toggle-switch.students .highlight {

--- a/atd/src/app/components/what-we-offer/what-we-offer.component.scss
+++ b/atd/src/app/components/what-we-offer/what-we-offer.component.scss
@@ -114,7 +114,7 @@
     padding: 2rem 1rem;
     row-gap: 0;
     gap: 2rem;
-    opacity: 1; // Always visible on mobile
+    opacity: 0; // Restore toggle functionality - only active grid visible
   }
 }
 
@@ -124,7 +124,8 @@
   z-index: 1;
 
   @include respond-to('mobile') {
-    // Ensure mobile stays visible regardless of active state
+    // Maintain toggle functionality on mobile
     opacity: 1;
+    pointer-events: auto;
   }
 }

--- a/atd/src/app/components/what-we-offer/what-we-offer.component.scss
+++ b/atd/src/app/components/what-we-offer/what-we-offer.component.scss
@@ -1,11 +1,20 @@
 
 
 @use "fonts" as *;
-
+@use "breakpoints" as *;
 
 .container {
-  width: 1303px;
+  width: min(100vw, 1303px); // Responsive from desktop, max 1303px
   height: auto;
+  margin: 0 auto; // Center the container
+
+  @include respond-to('tablet') {
+    width: min(90vw, 1000px); // Scale down while maintaining aspect ratio
+  }
+
+  @include respond-to('mobile') {
+    width: 95vw;
+  }
 }
 
 .header-container {
@@ -14,6 +23,17 @@
   justify-content: center; // Center the content horizontally
   align-items: center; // Center the content vertically
   position: relative; // Add relative positioning for absolute children
+
+  @include respond-to('tablet') {
+    height: 55px;
+  }
+
+  @include respond-to('mobile') {
+    height: 50px;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem 0;
+  }
 }
 
 .title-box {
@@ -21,40 +41,90 @@
   gap: 1rem;
   position: absolute; // Position title absolutely
   left: 0; // Align to left
+
+  @include respond-to('mobile') {
+    position: static;
+    justify-content: center;
+  }
 }
 
 .title {
   align-content: center;
   font-family: $font-primary;
-  font-size: $font-size-base;
+  font-size: $font-size-base; // Desktop
   font-weight: $font-weight-bold;
 
+  @include respond-to('tablet') {
+    font-size: $font-size-base-sm;
+  }
+
+  @include respond-to('mobile') {
+    font-size: $font-size-sm;
+  }
 }
 
 .offer-box {
   background-image: url("/images/what-we-do-background.svg");
   background-repeat: no-repeat;
-  background-size: auto;
+  background-size: contain; // Scale background with container
   background-position: center;
   width: 100%;
-  aspect-ratio: 1303/652;
+  aspect-ratio: 1303/652; // Desktop aspect ratio
   position: relative;
+
+  @include respond-to('tablet') {
+    // Maintain aspect ratio and background scaling
+    aspect-ratio: 1303/652;
+    background-size: contain;
+  }
+
+  @include respond-to('mobile') {
+    // Remove background and reset layout for mobile
+    background-image: none;
+    background: none;
+    aspect-ratio: auto;
+    height: auto;
+    position: static;
+  }
 }
 
 .offer-grid {
   display: grid;
-  grid-template-columns: 3fr 1fr;
+  grid-template-columns: 3fr 1fr; // Desktop grid
   justify-content: start;
-  row-gap: 8rem;
-  padding: 7rem 12rem;
+  row-gap: clamp(4rem, 8vw, 8rem); // Responsive gap that scales with viewport
+  padding: clamp(3rem, 7vw, 7rem) clamp(6rem, 12vw, 12rem); // Responsive padding
   position: absolute;
   opacity: 0;
   transition: opacity 0.3s ease-in-out;
   z-index: 0;
+
+  @include respond-to('tablet') {
+    // Maintain grid but adjust padding proportionally
+    padding: clamp(2.5rem, 5vw, 5rem) clamp(4rem, 8vw, 8rem);
+    row-gap: clamp(2.5rem, 5vw, 5rem);
+  }
+
+  @include respond-to('mobile') {
+    // Switch to column layout for mobile
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: none;
+    position: static;
+    padding: 2rem 1rem;
+    row-gap: 0;
+    gap: 2rem;
+    opacity: 1; // Always visible on mobile
+  }
 }
 
 .offer-grid.active {
   opacity: 1;
   pointer-events: auto;
   z-index: 1;
+
+  @include respond-to('mobile') {
+    // Ensure mobile stays visible regardless of active state
+    opacity: 1;
+  }
 }

--- a/atd/src/app/pages/join-us-page/join-us-page.component.scss
+++ b/atd/src/app/pages/join-us-page/join-us-page.component.scss
@@ -29,7 +29,7 @@
 
 .header-container {
   position: absolute;
-  top: 180px;
+  top: 125px;
   left: 100px;
   z-index: 2;
 }

--- a/atd/src/app/pages/main-page/main-page.component.scss
+++ b/atd/src/app/pages/main-page/main-page.component.scss
@@ -54,11 +54,13 @@ app-what-we-offer {
     margin-bottom: 240px; // Desktop spacing
 
     @include respond-to('tablet') {
-        margin-bottom: 150px;
+        display: none; // Hide component on mobile screens
+        margin-bottom: 0; // Remove margin since it's hidden
     }
 
     @include respond-to('mobile') {
-        margin-bottom: 100px;
+        display: none; // Hide component on mobile screens
+        margin-bottom: 0; // Remove margin since it's hidden
     }
 }
 

--- a/atd/src/app/pages/main-page/main-page.component.scss
+++ b/atd/src/app/pages/main-page/main-page.component.scss
@@ -1,3 +1,5 @@
+@use "breakpoints" as *;
+
 .main-page-container {
     display: flex;
     flex-direction: column;
@@ -6,30 +8,84 @@
 
 /* Custom margins for spacing between components */
 app-definition-box {
-    margin-top: 100px; // Space above Definition Box
-    margin-bottom: 150px; // Space below Definition Box
+    margin-top: 100px; // Desktop spacing
+    margin-bottom: 150px;
+
+    @include respond-to('tablet') {
+        margin-top: 60px;
+        margin-bottom: 100px;
+    }
+
+    @include respond-to('mobile') {
+        margin-top: 40px;
+        margin-bottom: 60px;
+    }
 }
 
 app-team-values-carousel {
-    margin-bottom: 240px; // Space below Team Values Carousel
-    width: 70%; // Set width to 80% of the home page width
+    margin-bottom: 240px; // Desktop spacing
+    width: 70%; // Desktop width
+
+    @include respond-to('tablet') {
+        margin-bottom: 150px;
+        width: 85%;
+    }
+
+    @include respond-to('mobile') {
+        margin-bottom: 100px;
+        width: 95%;
+    }
 }
 
 app-event-calender-box {
-    margin-bottom: 200px; // Space below Event Calendar Box
+    margin-bottom: 200px; // Desktop spacing
     width: 100%;
+
+    @include respond-to('tablet') {
+        margin-bottom: 120px;
+    }
+
+    @include respond-to('mobile') {
+        margin-bottom: 80px;
+    }
 }
 
 app-what-we-offer {
-    margin-bottom: 240px; // Space below What We Offer
+    margin-bottom: 240px; // Desktop spacing
+
+    @include respond-to('tablet') {
+        margin-bottom: 150px;
+    }
+
+    @include respond-to('mobile') {
+        margin-bottom: 100px;
+    }
 }
 
 app-contact-box {
-    margin-bottom: 30px; // Space below Contact Box
-    width: 80%; 
+    margin-bottom: 30px; // Desktop spacing
+    width: 80%; // Desktop width
+
+    @include respond-to('tablet') {
+        margin-bottom: 20px;
+        width: 90%;
+    }
+
+    @include respond-to('mobile') {
+        margin-bottom: 15px;
+        width: 95%;
+    }
 }
 
 app-faq-section {
-    margin-bottom: 140px; // Space below FAQ Section
+    margin-bottom: 140px; // Desktop spacing
     width: 100%;
+
+    @include respond-to('tablet') {
+        margin-bottom: 80px;
+    }
+
+    @include respond-to('mobile') {
+        margin-bottom: 60px;
+    }
 }

--- a/atd/src/app/pages/main-page/main-page.component.scss
+++ b/atd/src/app/pages/main-page/main-page.component.scss
@@ -80,7 +80,6 @@ app-contact-box {
 }
 
 app-faq-section {
-    background-color: purple;
     margin-bottom: 140px; // Desktop spacing
     width: 100%;
 

--- a/atd/src/app/pages/main-page/main-page.component.scss
+++ b/atd/src/app/pages/main-page/main-page.component.scss
@@ -80,6 +80,7 @@ app-contact-box {
 }
 
 app-faq-section {
+    background-color: purple;
     margin-bottom: 140px; // Desktop spacing
     width: 100%;
 

--- a/atd/src/app/pages/main-page/main-page.component.scss
+++ b/atd/src/app/pages/main-page/main-page.component.scss
@@ -12,7 +12,7 @@ app-definition-box {
 
 app-team-values-carousel {
     margin-bottom: 240px; // Space below Team Values Carousel
-    width: 80%; // Set width to 80% of the home page width
+    width: 70%; // Set width to 80% of the home page width
 }
 
 app-event-calender-box {

--- a/atd/src/styles/_breakpoints.scss
+++ b/atd/src/styles/_breakpoints.scss
@@ -1,0 +1,17 @@
+// Breakpoint definitions
+$mobile: 480px;
+$tablet: 768px;
+$desktop: 1024px;
+
+// Responsive mixins
+@mixin respond-to($breakpoint) {
+  @if $breakpoint == 'mobile' {
+    @media (max-width: $mobile) { @content; }
+  }
+  @else if $breakpoint == 'tablet' {
+    @media (max-width: $tablet) { @content; }
+  }
+  @else if $breakpoint == 'desktop' {
+    @media (min-width: $desktop) { @content; }
+  }
+}


### PR DESCRIPTION
- Added resizing support for the navbar, footer, and the main page. 
- We resize based on three main sizes: Desktop, Tablet, and Mobile. For each one, we use default styling (what we already have) for desktop, and use @include for any modifications to sizes for Tablet and Mobile. See code for reference.
- For the navbar, when we shrink down to mobile, added a hamburger button that drops down and shows the navbar buttons.